### PR TITLE
fix(litestock): add stock count types to requests

### DIFF
--- a/src/components/ReplenishStockCount/ReplenishStock.tsx
+++ b/src/components/ReplenishStockCount/ReplenishStock.tsx
@@ -12,6 +12,7 @@ import StockCountSummary from "../StockCountSummary";
 import Loader from "../Loader";
 import { Product } from "../../types/Product";
 import { displayErrorFromServer } from "../../utils/errorHandlingUtils";
+import { StockCountType } from "../../enums/stockCountType";
 
 const replenishLocalStorageKey = "REPLENISH";
 
@@ -77,6 +78,7 @@ export default function Home() {
             deviceId: p.deviceId,
             salesAreaId: 1,
             product: p,
+            stockCountType: StockCountType.Replenishment
           };
         });
 

--- a/src/components/StockCount/StockCount.tsx
+++ b/src/components/StockCount/StockCount.tsx
@@ -12,6 +12,7 @@ import StickyButton from "../StickyButton";
 import StockCountSummary from "../StockCountSummary";
 import { postStockcount } from "../../apiRequests/StockCount";
 import { displayErrorFromServer } from "../../utils/errorHandlingUtils";
+import { StockCountType } from "../../enums/stockCountType";
 
 const localStorageKey = "STOCKCOUNT";
 
@@ -137,6 +138,7 @@ export default function StockCount() {
           deviceId: p.deviceId,
           salesAreaId: 1,
           product: p,
+          stockCountType: StockCountType.StockCount
         };
       });
 

--- a/src/enums/stockCountType.tsx
+++ b/src/enums/stockCountType.tsx
@@ -1,0 +1,5 @@
+export enum StockCountType {
+    StockCount = 1,
+    Replenishment = 2,
+    Wastage = 3
+}

--- a/src/types/ProductStockCount.tsx
+++ b/src/types/ProductStockCount.tsx
@@ -8,4 +8,5 @@ export interface ProductStockCount {
   product?: Product;
   created?: Date;
   id?: number;
+  stockCountType?: number;
 }


### PR DESCRIPTION
# PR Details

Jira Issue Reference: <!-- ✍️-->CSH-2467

## Brief description of what has been changed?

<!-- ✍️-->Added Stock count types as an enum and updated the Litestock endpoint requests to include stock count type. 
This should differentiate records on the stock count table in the db based on it's type (Stock count, replenishment or wastage)
<!-- ✍️ Use this space to detail any other details relevant to the pull request. -->

## Depends on another PR (or another PR in another Project)
https://github.com/CounterSolutions/Way2Pay.Ng.ApiX/pull/220

<!-- Please check the one that applies to this PR using "x". If yes also add the corresponding tag. -->

- [x] Yes
- [ ] No

<!-- ✍️ Specify which PR or PR in another project this relies on. CounterSolutions/<Repo>#<PRNumber> -->

## Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x". If yes also add the corresponding tag. -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
